### PR TITLE
Shimmed sparky.js for use with Browserify/NPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/*

--- a/browserify.js
+++ b/browserify.js
@@ -1,0 +1,3 @@
+var sparky = require('sparky');
+
+module.exports = sparky;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "sparky",
+  "version": "0.2.1",
+  "description": "Sparky is a JavaScript library for drawing Sparklines dynamically in your web browser. ",
+  "directories": {
+    "example": "examples"
+  },
+  "main": "browserify.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/shawnbot/sparky.git"
+  },
+  "author": "Shawn Allen",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/shawnbot/sparky/issues"
+  },
+  "homepage": "https://github.com/shawnbot/sparky",
+  "browserify": {
+    "transform": [
+      "browserify-shim"
+    ]
+  },
+  "browser": {
+    "raphael": "./lib/raphael/raphael-min.js",
+    "sparky": "./src/sparky.js"
+  },
+  "browserify-shim": {
+    "raphael": "Raphael",
+    "sparky": {
+      "exports": "sparky",
+      "depends": [
+        "raphael:Raphael"
+      ]
+    }
+  },
+  "dependencies": {
+    "browserify": "^7.0.0",
+    "browserify-shim": "^3.8.1"
+  }
+}


### PR DESCRIPTION
I went ahead and did a simple shim of this library (and its included Raphael dependency) so that it can be included on NPM if you are interested in that, as well making it requirable via browserify.  

Here is an example:

``` js
var sparky = require('sparky');

window.onload = init;

function init() {
  sparky.presets.set("big", {
      ...etc
  })
}
```

Next steps would be to start using https://www.npmjs.org/package/raphael instead of including a copy in the repo and exporting sparky rather than shimming a global variable.  I can help out with this if you are interested.
